### PR TITLE
feat: add basic client and server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ dist
 
 # TernJS port file
 .tern-port
+data.json

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ This project targets the latest Node.js LTS release. Ensure your environment use
 ## Running Locally
 
 1. Install dependencies: `npm install`.
-2. Use the npm scripts below to develop, test, and build the project.
+2. Build the project: `npm run build`.
+3. Start the server: `npm start` and visit http://localhost:3000.
+4. Use the npm scripts below to develop, test, and build the project.
 
 ## npm Scripts
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "My typescript starter template",
   "main": "dist/index.js",
   "scripts": {
-    "start": "node dist/index.js",
+    "start": "node dist/server.js",
     "build": "tsc -p tsconfig.build.json",
     "build:fast": "tsc -p tsconfig.build.json --strict false --listEmittedFiles --skipLibCheck --incremental --tsBuildInfoFile ./.tsBuildInfo",
     "lint": "ESLINT_USE_FLAT_CONFIG=false eslint -c .eslintrc.cjs --ext .ts src",
@@ -13,7 +13,7 @@
     "watch": "onchange \"src/**/*.ts\" \"src/*.ts\" -e \"dist/*\" \"tests/*\" -- npm run check",
     "test": "jest",
     "prepare": "husky",
-    "dev": "ts-node-dev --respawn src/index.ts",
+    "dev": "ts-node-dev --respawn src/server.ts",
     "format": "prettier --write .",
     "commit": "cz"
   },

--- a/public/index.html
+++ b/public/index.html
@@ -6,13 +6,20 @@
   <title>Journal</title>
   <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css" />
 </head>
-<body class="w3-container">
-  <form id="unlock-form" class="w3-margin-top">
-    <label for="password">Password</label>
-    <input class="w3-input w3-margin-bottom" type="password" id="password" />
-    <button class="w3-button w3-blue" type="submit">Unlock</button>
-  </form>
-  <h1 id="title" class="w3-center"></h1>
+<body>
+  <div class="w3-container" style="max-width:600px;margin:auto">
+    <div id="unlock-view" class="w3-card w3-padding w3-margin-top">
+      <form id="unlock-form">
+        <label for="password">Password</label>
+        <input class="w3-input w3-margin-bottom" type="password" id="password" />
+        <button class="w3-button w3-blue" type="submit">Unlock</button>
+        <p id="error" class="w3-text-red"></p>
+      </form>
+    </div>
+    <div id="content-view" class="w3-card w3-padding w3-margin-top w3-center" style="display:none">
+      <h1 id="title"></h1>
+    </div>
+  </div>
   <script src="script.js"></script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Journal</title>
+  <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css" />
+</head>
+<body class="w3-container">
+  <form id="unlock-form" class="w3-margin-top">
+    <label for="password">Password</label>
+    <input class="w3-input w3-margin-bottom" type="password" id="password" />
+    <button class="w3-button w3-blue" type="submit">Unlock</button>
+  </form>
+  <h1 id="title" class="w3-center"></h1>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,16 @@
+const form = document.getElementById('unlock-form');
+const title = document.getElementById('title');
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const password = (document.getElementById('password')).value;
+  const res = await fetch('/api/unlock', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ password }),
+  });
+  if (res.ok) {
+    const data = await res.json();
+    title.textContent = data.title;
+  }
+});

--- a/public/script.js
+++ b/public/script.js
@@ -1,16 +1,34 @@
 const form = document.getElementById('unlock-form');
+const passwordInput = document.getElementById('password');
+const error = document.getElementById('error');
+const unlockView = document.getElementById('unlock-view');
+const contentView = document.getElementById('content-view');
 const title = document.getElementById('title');
 
 form.addEventListener('submit', async (e) => {
   e.preventDefault();
-  const password = (document.getElementById('password')).value;
-  const res = await fetch('/api/unlock', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ password }),
-  });
-  if (res.ok) {
-    const data = await res.json();
-    title.textContent = data.title;
+  error.textContent = '';
+  const password = passwordInput.value;
+  try {
+    const res = await fetch('/api/unlock', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      title.textContent = data.title;
+      unlockView.style.display = 'none';
+      contentView.style.display = 'block';
+    } else if (res.status === 400) {
+      const data = await res.json().catch(() => ({}));
+      error.textContent = data.error || 'Password required';
+    } else if (res.status >= 500) {
+      error.textContent = 'Server error. Please try again later.';
+    } else {
+      error.textContent = 'Unexpected error.';
+    }
+  } catch {
+    error.textContent = 'Network error.';
   }
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,81 @@
+import http from 'http';
+import fs from 'fs';
+import path from 'path';
+
+const publicDir = path.join(__dirname, '..', 'public');
+const dataPath = path.join(__dirname, '..', 'data.json');
+
+const ensureDataFile = (): void => {
+  if (!fs.existsSync(dataPath)) {
+    fs.writeFileSync(dataPath, JSON.stringify({ title: 'Journal' }, null, 2));
+  }
+};
+
+const serveStatic = (req: http.IncomingMessage, res: http.ServerResponse): boolean => {
+  if (req.method !== 'GET' || !req.url) return false;
+  const urlPath = req.url === '/' ? '/index.html' : req.url;
+  const filePath = path.join(publicDir, path.normalize(urlPath));
+  if (!filePath.startsWith(publicDir)) {
+    return false;
+  }
+  let contentType = 'text/plain';
+  if (filePath.endsWith('.html')) contentType = 'text/html';
+  else if (filePath.endsWith('.js')) contentType = 'application/javascript';
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.statusCode = 404;
+      res.end('Not found');
+      return;
+    }
+    res.setHeader('Content-Type', contentType);
+    res.end(data);
+  });
+  return true;
+};
+
+const handleUnlock = (req: http.IncomingMessage, res: http.ServerResponse): void => {
+  let body = '';
+  req.on('data', (chunk) => {
+    body += chunk;
+  });
+  req.on('end', () => {
+    try {
+      const { password } = JSON.parse(body);
+      if (!password || password.length === 0) {
+        res.statusCode = 400;
+        res.end(JSON.stringify({ error: 'Password required' }));
+        return;
+      }
+      ensureDataFile();
+      const content = fs.readFileSync(dataPath, 'utf8');
+      res.setHeader('Content-Type', 'application/json');
+      res.end(content);
+    } catch {
+      res.statusCode = 500;
+      res.end(JSON.stringify({ error: 'Server error' }));
+    }
+  });
+};
+
+export const createServer = (): http.Server => {
+  return http.createServer((req, res) => {
+    if (req.url === '/api/unlock' && req.method === 'POST') {
+      handleUnlock(req, res);
+      return;
+    }
+    if (serveStatic(req, res)) return;
+    res.statusCode = 404;
+    res.end('Not found');
+  });
+};
+
+export const startServer = (port = 3000): http.Server => {
+  const server = createServer();
+  return server.listen(port, () => {
+    console.log(`Server running on http://localhost:${port}`);
+  });
+};
+
+if (require.main === module) {
+  startServer();
+}

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1,0 +1,39 @@
+import { createServer } from '../src/server';
+import fs from 'fs';
+import path from 'path';
+import { AddressInfo } from 'net';
+
+const dataFile = path.join(__dirname, '..', 'data.json');
+
+describe('unlock API', () => {
+  let server: ReturnType<typeof createServer>;
+  let port: number;
+
+  beforeAll(async () => {
+    server = createServer();
+    await new Promise((resolve) => {
+      server.listen(0, () => {
+        port = (server.address() as AddressInfo).port;
+        resolve(null);
+      });
+    });
+  });
+
+  afterAll(() => {
+    server.close();
+    if (fs.existsSync(dataFile)) fs.unlinkSync(dataFile);
+  });
+
+  it('creates data file and returns title', async () => {
+    if (fs.existsSync(dataFile)) fs.unlinkSync(dataFile);
+    const res = await fetch(`http://localhost:${port}/api/unlock`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password: 'secret' }),
+    });
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.title).toBeDefined();
+    expect(fs.existsSync(dataFile)).toBe(true);
+  });
+});

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -36,4 +36,14 @@ describe('unlock API', () => {
     expect(json.title).toBeDefined();
     expect(fs.existsSync(dataFile)).toBe(true);
   });
+  it('responds with 400 when password missing', async () => {
+    const res = await fetch(`http://localhost:${port}/api/unlock`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password: '' }),
+    });
+    const json = await res.json();
+    expect(res.status).toBe(400);
+    expect(json.error).toBeDefined();
+  });
 });


### PR DESCRIPTION
## Summary
- serve static client with password form and API
- handle unlock requests and respond with JSON title from local file
- document how to build and run server and add API test

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b471487d08832bb1151d1f617c1e3d