### PR TITLE
feat: add encrypted storage with signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ A minimal TypeScript project for a browser-based journal client. The HTML
 interface uses vanilla JavaScript and [w3.css](https://www.w3schools.com/w3css/).
 Journal entries are encrypted locally using a symmetric key derived from a
 user-provided password. The key is never stored and session data is not
-persisted.
+persisted. Each save produces a new signing key pair: the public key is written
+to disk for verification while the private key is sealed inside the encrypted
+payload. The encrypted file also records a UTC timestamp and a SHA-256 hash of
+the ciphertext to protect against tampering.
 
 ## Project Guidelines
 

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -1,0 +1,106 @@
+import {promises as fs} from 'fs';
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHash,
+  createPublicKey,
+  generateKeyPairSync,
+  pbkdf2Sync,
+  randomBytes,
+  sign,
+  verify,
+} from 'crypto';
+
+interface EncryptedFile {
+  timestamp: string;
+  hash: string;
+  salt: string;
+  iv: string;
+  tag: string;
+  data: string;
+  signature: string;
+}
+
+const deriveKey = (password: string, salt: Buffer): Buffer => {
+  return pbkdf2Sync(password, salt, 100_000, 32, 'sha256');
+};
+
+export const saveEncrypted = async (
+  password: string,
+  payload: unknown,
+  dataPath: string,
+  pubKeyPath: string,
+): Promise<void> => {
+  const salt = randomBytes(16);
+  const iv = randomBytes(12);
+  const key = deriveKey(password, salt);
+
+  const {privateKey, publicKey} = generateKeyPairSync('ed25519');
+  const privPem = privateKey.export({format: 'pem', type: 'pkcs8'});
+  const plaintext = JSON.stringify({payload, privateKey: privPem});
+
+  const cipher = createCipheriv('aes-256-gcm', key, iv);
+  const encrypted = Buffer.concat([
+    cipher.update(plaintext, 'utf8'),
+    cipher.final(),
+  ]);
+  const tag = cipher.getAuthTag();
+
+  const hash = createHash('sha256').update(encrypted).digest('hex');
+  const signature = sign(null, encrypted, privateKey);
+
+  const file: EncryptedFile = {
+    timestamp: new Date().toISOString(),
+    hash,
+    salt: salt.toString('base64'),
+    iv: iv.toString('base64'),
+    tag: tag.toString('base64'),
+    data: encrypted.toString('base64'),
+    signature: signature.toString('base64'),
+  };
+
+  await fs.writeFile(dataPath, JSON.stringify(file, null, 2));
+  const pubPem = publicKey.export({format: 'pem', type: 'spki'});
+  await fs.writeFile(pubKeyPath, pubPem);
+};
+
+export const loadEncrypted = async (
+  password: string,
+  dataPath: string,
+  pubKeyPath: string,
+): Promise<{payload: unknown; privateKey: string}> => {
+  const [fileStr, pubPem] = await Promise.all([
+    fs.readFile(dataPath, 'utf8'),
+    fs.readFile(pubKeyPath, 'utf8'),
+  ]);
+  const file: EncryptedFile = JSON.parse(fileStr);
+  const encrypted = Buffer.from(file.data, 'base64');
+  const signature = Buffer.from(file.signature, 'base64');
+  const publicKey = createPublicKey(pubPem);
+
+  if (!verify(null, encrypted, publicKey, signature)) {
+    throw new Error('Signature verification failed');
+  }
+
+  const hash = createHash('sha256').update(encrypted).digest('hex');
+  if (hash !== file.hash) {
+    throw new Error('Hash mismatch');
+  }
+
+  const salt = Buffer.from(file.salt, 'base64');
+  const key = deriveKey(password, salt);
+  const iv = Buffer.from(file.iv, 'base64');
+  const tag = Buffer.from(file.tag, 'base64');
+
+  const decipher = createDecipheriv('aes-256-gcm', key, iv);
+  decipher.setAuthTag(tag);
+  const decrypted = Buffer.concat([
+    decipher.update(encrypted),
+    decipher.final(),
+  ]);
+  return JSON.parse(decrypted.toString('utf8')) as {
+    payload: unknown;
+    privateKey: string;
+  };
+};
+

--- a/tests/crypto.test.ts
+++ b/tests/crypto.test.ts
@@ -1,0 +1,32 @@
+import {promises as fs, mkdtempSync, rmSync} from 'fs';
+import os from 'os';
+import path from 'path';
+import {loadEncrypted, saveEncrypted} from '../src/utils/crypto';
+
+describe('encryption flow', () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'journal-'));
+  const dataPath = path.join(dir, 'data.json');
+  const pubPath = path.join(dir, 'data.pub');
+  const password = 'supersecret';
+  const payload = {entries: ['test']};
+
+  afterAll(() => rmSync(dir, {recursive: true, force: true}));
+
+  it('encrypts and decrypts data', async () => {
+    await saveEncrypted(password, payload, dataPath, pubPath);
+    const result = await loadEncrypted(password, dataPath, pubPath);
+    expect(result.payload).toEqual(payload);
+    expect(typeof result.privateKey).toBe('string');
+  });
+
+  it('detects tampering', async () => {
+    await saveEncrypted(password, payload, dataPath, pubPath);
+    const obj = JSON.parse(await fs.readFile(dataPath, 'utf8'));
+    const buf = Buffer.from(obj.data, 'base64');
+    buf[0] ^= 0xff; // corrupt
+    obj.data = buf.toString('base64');
+    await fs.writeFile(dataPath, JSON.stringify(obj));
+    await expect(loadEncrypted(password, dataPath, pubPath)).rejects.toThrow();
+  });
+});
+


### PR DESCRIPTION
## Summary
- derive keys from passwords to encrypt JSON payloads
- sign ciphertext with rotating Ed25519 key pairs
- verify, hash, and decrypt stored entries

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b47bdc7c10832b817f7249d929e8f8