### PR TITLE
feat: structure journal payload

### DIFF
--- a/src/models/journal.ts
+++ b/src/models/journal.ts
@@ -1,0 +1,15 @@
+export interface Entry {
+  id: string;
+  timestamp: string;
+  content: string;
+}
+
+export interface Day {
+  summary: string;
+  entries: Entry[];
+}
+
+export interface Journal {
+  title: string;
+  days: Record<string, Day>;
+}

--- a/tests/crypto.test.ts
+++ b/tests/crypto.test.ts
@@ -2,13 +2,28 @@ import {promises as fs, mkdtempSync, rmSync} from 'fs';
 import os from 'os';
 import path from 'path';
 import {loadEncrypted, saveEncrypted} from '../src/utils/crypto';
+import {Journal} from '../src/models/journal';
 
 describe('encryption flow', () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), 'journal-'));
   const dataPath = path.join(dir, 'data.json');
   const pubPath = path.join(dir, 'data.pub');
   const password = 'supersecret';
-  const payload = {entries: ['test']};
+  const payload: Journal = {
+    title: 'Test',
+    days: {
+      '2024-01-01': {
+        summary: 'New Year',
+        entries: [
+          {
+            id: '1',
+            timestamp: '2024-01-01T00:00:00.000Z',
+            content: 'Hello',
+          },
+        ],
+      },
+    },
+  };
 
   afterAll(() => rmSync(dir, {recursive: true, force: true}));
 

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -36,7 +36,8 @@ describe('unlock API', () => {
     });
     const json = await res.json();
     expect(res.status).toBe(200);
-    expect(json.payload.title).toBeDefined();
+    expect(json.payload.title).toBe('Journal');
+    expect(json.payload.days).toEqual({});
     expect(typeof json.privateKey).toBe('string');
     expect(fs.existsSync(dataFile)).toBe(true);
     expect(fs.existsSync(pubFile)).toBe(true);


### PR DESCRIPTION
## Summary
- define journal entry models and day mapping
- initialize journal data with title and day records
- update encryption tests for new data shape

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b48f43e22c832b946825802d4a7e5a