### PR TITLE
feat: add journal entry and summary APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ This project targets the latest Node.js LTS release. Ensure your environment use
 3. Start the server: `npm start` and visit http://localhost:3000.
 4. Use the npm scripts below to develop, test, and build the project.
 
+## API Endpoints
+
+The server exposes a small JSON API:
+
+- `POST /api/unlock` – supply `{password}` to decrypt the journal.
+- `GET /api/entries?date=YYYY-MM-DD` – retrieve `{summary, entries}` for a day.
+- `POST /api/entries` – send `{date, content}` to append a new entry.
+- `PUT /api/entries/:id` – update an entry's `{content}` and optional `timestamp`.
+- `PUT /api/summary/:date` – update the summary for the given day.
+
 ## npm Scripts
 
 | Script | Description |

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -6,7 +6,7 @@ import {AddressInfo} from 'net';
 const dataFile = path.join(__dirname, '..', 'data.json');
 const pubFile = path.join(__dirname, '..', 'data.pub');
 
-describe('unlock API', () => {
+describe('server APIs', () => {
   let server: ReturnType<typeof createServer>;
   let port: number;
 
@@ -26,30 +26,106 @@ describe('unlock API', () => {
     if (fs.existsSync(pubFile)) fs.unlinkSync(pubFile);
   });
 
-  it('creates encrypted data file and returns payload', async () => {
-    if (fs.existsSync(dataFile)) fs.unlinkSync(dataFile);
-    if (fs.existsSync(pubFile)) fs.unlinkSync(pubFile);
-    const res = await fetch(`http://localhost:${port}/api/unlock`, {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({password: 'secret'}),
+  describe('unlock API', () => {
+    it('creates encrypted data file and returns payload', async () => {
+      if (fs.existsSync(dataFile)) fs.unlinkSync(dataFile);
+      if (fs.existsSync(pubFile)) fs.unlinkSync(pubFile);
+      const res = await fetch(`http://localhost:${port}/api/unlock`, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({password: 'secret'}),
+      });
+      const json = await res.json();
+      expect(res.status).toBe(200);
+      expect(json.payload.title).toBe('Journal');
+      expect(json.payload.days).toEqual({});
+      expect(typeof json.privateKey).toBe('string');
+      expect(fs.existsSync(dataFile)).toBe(true);
+      expect(fs.existsSync(pubFile)).toBe(true);
     });
-    const json = await res.json();
-    expect(res.status).toBe(200);
-    expect(json.payload.title).toBe('Journal');
-    expect(json.payload.days).toEqual({});
-    expect(typeof json.privateKey).toBe('string');
-    expect(fs.existsSync(dataFile)).toBe(true);
-    expect(fs.existsSync(pubFile)).toBe(true);
+
+    it('responds with 400 when password missing', async () => {
+      const res = await fetch(`http://localhost:${port}/api/unlock`, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({password: ''}),
+      });
+      const json = await res.json();
+      expect(res.status).toBe(400);
+      expect(json.error).toBeDefined();
+    });
   });
-  it('responds with 400 when password missing', async () => {
-    const res = await fetch(`http://localhost:${port}/api/unlock`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ password: '' }),
+
+  describe('entries API', () => {
+    const date = '2024-01-02';
+    let entryId: string;
+
+    beforeAll(async () => {
+      await fetch(`http://localhost:${port}/api/unlock`, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({password: 'secret'}),
+      });
     });
-    const json = await res.json();
-    expect(res.status).toBe(400);
-    expect(json.error).toBeDefined();
+
+    it('appends an entry', async () => {
+      const res = await fetch(`http://localhost:${port}/api/entries`, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({date, content: 'hello'}),
+      });
+      const json = (await res.json()) as {id: string; content: string};
+      expect(res.status).toBe(201);
+      expect(json.content).toBe('hello');
+      entryId = json.id;
+    });
+
+    it('retrieves entries for the day', async () => {
+      const res = await fetch(
+        `http://localhost:${port}/api/entries?date=${date}`,
+      );
+      const json = await res.json();
+      expect(res.status).toBe(200);
+      expect(json.entries).toHaveLength(1);
+      expect(json.summary).toBe('');
+    });
+
+    it('updates an entry', async () => {
+      const res = await fetch(
+        `http://localhost:${port}/api/entries/${entryId}`,
+        {
+          method: 'PUT',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({content: 'updated'}),
+        },
+      );
+      const json = await res.json();
+      expect(res.status).toBe(200);
+      expect(json.content).toBe('updated');
+    });
+
+    it('updates summary', async () => {
+      const res = await fetch(
+        `http://localhost:${port}/api/summary/${date}`,
+        {
+          method: 'PUT',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({summary: 'great day'}),
+        },
+      );
+      const json = await res.json();
+      expect(res.status).toBe(200);
+      expect(json.summary).toBe('great day');
+    });
+
+    it('reflects updates when fetching day', async () => {
+      const res = await fetch(
+        `http://localhost:${port}/api/entries?date=${date}`,
+      );
+      const json = await res.json();
+      expect(json.summary).toBe('great day');
+      expect(json.entries[0].content).toBe('updated');
+    });
   });
 });
+


### PR DESCRIPTION
## Summary
- add GET/POST/PUT handlers for journal entries and daily summaries
- document API endpoints in README
- cover new routes with server tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b491868518832b95f61859c076951c