### PR TITLE
fix: enforce password per request for journal APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ This project targets the latest Node.js LTS release. Ensure your environment use
 
 ## API Endpoints
 
-The server exposes a small JSON API:
+The server exposes a small JSON API. All endpoints except `/api/unlock` require
+an `X-Password` header containing the user's password:
 
 - `POST /api/unlock` – supply `{password}` to decrypt the journal.
 - `GET /api/entries?date=YYYY-MM-DD` – retrieve `{summary, entries}` for a day.

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -71,7 +71,10 @@ describe('server APIs', () => {
     it('appends an entry', async () => {
       const res = await fetch(`http://localhost:${port}/api/entries`, {
         method: 'POST',
-        headers: {'Content-Type': 'application/json'},
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Password': 'secret',
+        },
         body: JSON.stringify({date, content: 'hello'}),
       });
       const json = (await res.json()) as {id: string; content: string};
@@ -83,6 +86,7 @@ describe('server APIs', () => {
     it('retrieves entries for the day', async () => {
       const res = await fetch(
         `http://localhost:${port}/api/entries?date=${date}`,
+        {headers: {'X-Password': 'secret'}},
       );
       const json = await res.json();
       expect(res.status).toBe(200);
@@ -95,7 +99,10 @@ describe('server APIs', () => {
         `http://localhost:${port}/api/entries/${entryId}`,
         {
           method: 'PUT',
-          headers: {'Content-Type': 'application/json'},
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Password': 'secret',
+          },
           body: JSON.stringify({content: 'updated'}),
         },
       );
@@ -109,7 +116,10 @@ describe('server APIs', () => {
         `http://localhost:${port}/api/summary/${date}`,
         {
           method: 'PUT',
-          headers: {'Content-Type': 'application/json'},
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Password': 'secret',
+          },
           body: JSON.stringify({summary: 'great day'}),
         },
       );
@@ -121,10 +131,17 @@ describe('server APIs', () => {
     it('reflects updates when fetching day', async () => {
       const res = await fetch(
         `http://localhost:${port}/api/entries?date=${date}`,
+        {headers: {'X-Password': 'secret'}},
       );
       const json = await res.json();
       expect(json.summary).toBe('great day');
       expect(json.entries[0].content).toBe('updated');
+    });
+    it('rejects requests without password', async () => {
+      const res = await fetch(
+        `http://localhost:${port}/api/entries?date=${date}`,
+      );
+      expect(res.status).toBe(403);
     });
   });
 });


### PR DESCRIPTION
## Summary
- require X-Password header on journal endpoints
- remove global password cache to avoid unlocked state
- update tests and docs for per-request authentication

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b498d96c78832bab35266520cb1ae5