### PR TITLE
fix: require per-request password and serialize journal writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This project targets the latest Node.js LTS release. Ensure your environment use
 The server exposes a small JSON API:
 
 - `POST /api/unlock` – supply `{password}` to decrypt the journal.
+- All other endpoints require the password in an `x-password` header.
 - `GET /api/entries?date=YYYY-MM-DD` – retrieve `{summary, entries}` for a day.
 - `POST /api/entries` – send `{date, content}` to append a new entry.
 - `PUT /api/entries/:id` – update an entry's `{content}` and optional `timestamp`.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ This project targets the latest Node.js LTS release. Ensure your environment use
 3. Start the server: `npm start` and visit http://localhost:3000.
 4. Use the npm scripts below to develop, test, and build the project.
 
+## API Endpoints
+
+The server exposes a small JSON API:
+
+- `POST /api/unlock` – supply `{password}` to decrypt the journal.
+- `GET /api/entries?date=YYYY-MM-DD` – retrieve `{summary, entries}` for a day.
+- `POST /api/entries` – send `{date, content}` to append a new entry.
+- `PUT /api/entries/:id` – update an entry's `{content}` and optional `timestamp`.
+- `PUT /api/summary/:date` – update the summary for the given day.
+
 ## npm Scripts
 
 | Script | Description |

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,7 +10,42 @@ const publicDir = path.join(__dirname, '..', 'public');
 const dataPath = path.join(__dirname, '..', 'data.json');
 const pubKeyPath = path.join(__dirname, '..', 'data.pub');
 
-let currentPassword: string | null = null;
+let writeLock: Promise<void> = Promise.resolve();
+
+const getPassword = (req: http.IncomingMessage): string | null => {
+  const pwd = req.headers['x-password'];
+  if (typeof pwd !== 'string' || pwd.length === 0) return null;
+  return pwd;
+};
+
+const readJournal = async (password: string): Promise<Journal> => {
+  await writeLock;
+  const {payload} = (await loadEncrypted(
+    password,
+    dataPath,
+    pubKeyPath,
+  )) as {payload: Journal};
+  return payload as Journal;
+};
+
+const updateJournal = async <T>(
+  password: string,
+  fn: (journal: Journal) => T | Promise<T>,
+): Promise<T> => {
+  let result: T;
+  writeLock = writeLock.then(async () => {
+    const {payload} = (await loadEncrypted(
+      password,
+      dataPath,
+      pubKeyPath,
+    )) as {payload: Journal};
+    const journal = payload as Journal;
+    result = await fn(journal);
+    await saveEncrypted(password, journal, dataPath, pubKeyPath);
+  });
+  await writeLock;
+  return result!;
+};
 
 const parseJson = (req: http.IncomingMessage): Promise<unknown> => {
   return new Promise((resolve, reject) => {
@@ -83,7 +118,6 @@ const handleUnlock = (req: http.IncomingMessage, res: http.ServerResponse): void
         dataPath,
         pubKeyPath,
       )) as {payload: Journal; privateKey: string};
-      currentPassword = password;
       res.setHeader('Content-Type', 'application/json');
       res.end(JSON.stringify(content));
     } catch (err) {
@@ -94,20 +128,16 @@ const handleUnlock = (req: http.IncomingMessage, res: http.ServerResponse): void
   });
 };
 
-const requireUnlocked = (res: http.ServerResponse): boolean => {
-  if (!currentPassword) {
-    res.statusCode = 403;
-    res.end(JSON.stringify({error: 'Locked'}));
-    return false;
-  }
-  return true;
-};
-
 const handleEntriesGet = async (
   req: http.IncomingMessage,
   res: http.ServerResponse,
 ): Promise<void> => {
-  if (!requireUnlocked(res) || !req.url) return;
+  const password = getPassword(req);
+  if (!password || !req.url) {
+    res.statusCode = 403;
+    res.end(JSON.stringify({error: 'Locked'}));
+    return;
+  }
   const url = new URL(req.url, 'http://localhost');
   const date = url.searchParams.get('date');
   if (!date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
@@ -116,12 +146,7 @@ const handleEntriesGet = async (
     return;
   }
   try {
-    const {payload} = (await loadEncrypted(
-      currentPassword as string,
-      dataPath,
-      pubKeyPath,
-    )) as {payload: Journal};
-    const journal = payload as Journal;
+    const journal = await readJournal(password);
     const day: Day = journal.days[date] || {summary: '', entries: []};
     res.setHeader('Content-Type', 'application/json');
     res.end(JSON.stringify(day));
@@ -136,7 +161,12 @@ const handleEntriesPost = async (
   req: http.IncomingMessage,
   res: http.ServerResponse,
 ): Promise<void> => {
-  if (!requireUnlocked(res)) return;
+  const password = getPassword(req);
+  if (!password) {
+    res.statusCode = 403;
+    res.end(JSON.stringify({error: 'Locked'}));
+    return;
+  }
   try {
     const {date, content} = (await parseJson(req)) as {
       date?: string;
@@ -152,20 +182,16 @@ const handleEntriesPost = async (
       res.end(JSON.stringify({error: 'Invalid input'}));
       return;
     }
-    const {payload} = (await loadEncrypted(
-      currentPassword as string,
-      dataPath,
-      pubKeyPath,
-    )) as {payload: Journal};
-    const journal = payload as Journal;
-    if (!journal.days[date]) journal.days[date] = {summary: '', entries: []};
-    const entry: Entry = {
-      id: randomUUID(),
-      timestamp: new Date().toISOString(),
-      content,
-    };
-    journal.days[date].entries.push(entry);
-    await saveEncrypted(currentPassword as string, journal, dataPath, pubKeyPath);
+    const entry = await updateJournal(password, (journal) => {
+      if (!journal.days[date]) journal.days[date] = {summary: '', entries: []};
+      const newEntry: Entry = {
+        id: randomUUID(),
+        timestamp: new Date().toISOString(),
+        content,
+      };
+      journal.days[date].entries.push(newEntry);
+      return newEntry;
+    });
     res.statusCode = 201;
     res.setHeader('Content-Type', 'application/json');
     res.end(JSON.stringify(entry));
@@ -181,7 +207,12 @@ const handleEntryPut = async (
   res: http.ServerResponse,
   id: string,
 ): Promise<void> => {
-  if (!requireUnlocked(res)) return;
+  const password = getPassword(req);
+  if (!password) {
+    res.statusCode = 403;
+    res.end(JSON.stringify({error: 'Locked'}));
+    return;
+  }
   try {
     const {content, timestamp} = (await parseJson(req)) as {
       content?: string;
@@ -197,31 +228,28 @@ const handleEntryPut = async (
       res.end(JSON.stringify({error: 'Invalid timestamp'}));
       return;
     }
-    const {payload} = (await loadEncrypted(
-      currentPassword as string,
-      dataPath,
-      pubKeyPath,
-    )) as {payload: Journal};
-    const journal = payload as Journal;
-    let found: Entry | null = null;
-    Object.values(journal.days).forEach((day) => {
-      day.entries.forEach((entry) => {
-        if (entry.id === id) {
-          entry.content = content;
-          if (timestamp) entry.timestamp = timestamp;
-          found = entry;
-        }
+    const found = await updateJournal(password, (journal) => {
+      let match: Entry | null = null;
+      Object.values(journal.days).forEach((day) => {
+        day.entries.forEach((entry) => {
+          if (entry.id === id) {
+            entry.content = content;
+            if (timestamp) entry.timestamp = timestamp;
+            match = entry;
+          }
+        });
       });
+      if (!match) throw new Error('not found');
+      return match;
     });
-    if (!found) {
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify(found));
+  } catch (err) {
+    if ((err as Error).message === 'not found') {
       res.statusCode = 404;
       res.end(JSON.stringify({error: 'Entry not found'}));
       return;
     }
-    await saveEncrypted(currentPassword as string, journal, dataPath, pubKeyPath);
-    res.setHeader('Content-Type', 'application/json');
-    res.end(JSON.stringify(found));
-  } catch (err) {
     logger.error(`Entry update failed: ${(err as Error).message}`);
     res.statusCode = 500;
     res.end(JSON.stringify({error: 'Server error'}));
@@ -233,7 +261,12 @@ const handleSummaryPut = async (
   res: http.ServerResponse,
   date: string,
 ): Promise<void> => {
-  if (!requireUnlocked(res)) return;
+  const password = getPassword(req);
+  if (!password) {
+    res.statusCode = 403;
+    res.end(JSON.stringify({error: 'Locked'}));
+    return;
+  }
   try {
     const {summary} = (await parseJson(req)) as {summary?: string};
     if (!summary) {
@@ -241,17 +274,13 @@ const handleSummaryPut = async (
       res.end(JSON.stringify({error: 'Invalid input'}));
       return;
     }
-    const {payload} = (await loadEncrypted(
-      currentPassword as string,
-      dataPath,
-      pubKeyPath,
-    )) as {payload: Journal};
-    const journal = payload as Journal;
-    if (!journal.days[date]) journal.days[date] = {summary: '', entries: []};
-    journal.days[date].summary = summary;
-    await saveEncrypted(currentPassword as string, journal, dataPath, pubKeyPath);
+    const day = await updateJournal(password, (journal) => {
+      if (!journal.days[date]) journal.days[date] = {summary: '', entries: []};
+      journal.days[date].summary = summary;
+      return journal.days[date];
+    });
     res.setHeader('Content-Type', 'application/json');
-    res.end(JSON.stringify(journal.days[date]));
+    res.end(JSON.stringify(day));
   } catch (err) {
     logger.error(`Summary update failed: ${(err as Error).message}`);
     res.statusCode = 500;

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -71,7 +71,10 @@ describe('server APIs', () => {
     it('appends an entry', async () => {
       const res = await fetch(`http://localhost:${port}/api/entries`, {
         method: 'POST',
-        headers: {'Content-Type': 'application/json'},
+        headers: {
+          'Content-Type': 'application/json',
+          'x-password': 'secret',
+        },
         body: JSON.stringify({date, content: 'hello'}),
       });
       const json = (await res.json()) as {id: string; content: string};
@@ -83,6 +86,9 @@ describe('server APIs', () => {
     it('retrieves entries for the day', async () => {
       const res = await fetch(
         `http://localhost:${port}/api/entries?date=${date}`,
+        {
+          headers: {'x-password': 'secret'},
+        },
       );
       const json = await res.json();
       expect(res.status).toBe(200);
@@ -95,7 +101,10 @@ describe('server APIs', () => {
         `http://localhost:${port}/api/entries/${entryId}`,
         {
           method: 'PUT',
-          headers: {'Content-Type': 'application/json'},
+          headers: {
+            'Content-Type': 'application/json',
+            'x-password': 'secret',
+          },
           body: JSON.stringify({content: 'updated'}),
         },
       );
@@ -109,7 +118,10 @@ describe('server APIs', () => {
         `http://localhost:${port}/api/summary/${date}`,
         {
           method: 'PUT',
-          headers: {'Content-Type': 'application/json'},
+          headers: {
+            'Content-Type': 'application/json',
+            'x-password': 'secret',
+          },
           body: JSON.stringify({summary: 'great day'}),
         },
       );
@@ -121,6 +133,9 @@ describe('server APIs', () => {
     it('reflects updates when fetching day', async () => {
       const res = await fetch(
         `http://localhost:${port}/api/entries?date=${date}`,
+        {
+          headers: {'x-password': 'secret'},
+        },
       );
       const json = await res.json();
       expect(json.summary).toBe('great day');

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -6,7 +6,7 @@ import {AddressInfo} from 'net';
 const dataFile = path.join(__dirname, '..', 'data.json');
 const pubFile = path.join(__dirname, '..', 'data.pub');
 
-describe('unlock API', () => {
+describe('server APIs', () => {
   let server: ReturnType<typeof createServer>;
   let port: number;
 
@@ -26,30 +26,106 @@ describe('unlock API', () => {
     if (fs.existsSync(pubFile)) fs.unlinkSync(pubFile);
   });
 
-  it('creates encrypted data file and returns payload', async () => {
-    if (fs.existsSync(dataFile)) fs.unlinkSync(dataFile);
-    if (fs.existsSync(pubFile)) fs.unlinkSync(pubFile);
-    const res = await fetch(`http://localhost:${port}/api/unlock`, {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({password: 'secret'}),
+  describe('unlock API', () => {
+    it('creates encrypted data file and returns payload', async () => {
+      if (fs.existsSync(dataFile)) fs.unlinkSync(dataFile);
+      if (fs.existsSync(pubFile)) fs.unlinkSync(pubFile);
+      const res = await fetch(`http://localhost:${port}/api/unlock`, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({password: 'secret'}),
+      });
+      const json = await res.json();
+      expect(res.status).toBe(200);
+      expect(json.payload.title).toBe('Journal');
+      expect(json.payload.days).toEqual({});
+      expect(typeof json.privateKey).toBe('string');
+      expect(fs.existsSync(dataFile)).toBe(true);
+      expect(fs.existsSync(pubFile)).toBe(true);
     });
-    const json = await res.json();
-    expect(res.status).toBe(200);
-    expect(json.payload.title).toBe('Journal');
-    expect(json.payload.days).toEqual({});
-    expect(typeof json.privateKey).toBe('string');
-    expect(fs.existsSync(dataFile)).toBe(true);
-    expect(fs.existsSync(pubFile)).toBe(true);
+
+    it('responds with 400 when password missing', async () => {
+      const res = await fetch(`http://localhost:${port}/api/unlock`, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({password: ''}),
+      });
+      const json = await res.json();
+      expect(res.status).toBe(400);
+      expect(json.error).toBeDefined();
+    });
   });
-  it('responds with 400 when password missing', async () => {
-    const res = await fetch(`http://localhost:${port}/api/unlock`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ password: '' }),
+
+  describe('entries API', () => {
+    const date = '2024-01-02';
+    let entryId: string;
+
+    beforeAll(async () => {
+      await fetch(`http://localhost:${port}/api/unlock`, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({password: 'secret'}),
+      });
     });
-    const json = await res.json();
-    expect(res.status).toBe(400);
-    expect(json.error).toBeDefined();
+
+    it('appends an entry', async () => {
+      const res = await fetch(`http://localhost:${port}/api/entries`, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({date, content: 'hello'}),
+      });
+      const json = (await res.json()) as {id: string; content: string};
+      expect(res.status).toBe(201);
+      expect(json.content).toBe('hello');
+      entryId = json.id;
+    });
+
+    it('retrieves entries for the day', async () => {
+      const res = await fetch(
+        `http://localhost:${port}/api/entries?date=${date}`,
+      );
+      const json = await res.json();
+      expect(res.status).toBe(200);
+      expect(json.entries).toHaveLength(1);
+      expect(json.summary).toBe('');
+    });
+
+    it('updates an entry', async () => {
+      const res = await fetch(
+        `http://localhost:${port}/api/entries/${entryId}`,
+        {
+          method: 'PUT',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({content: 'updated'}),
+        },
+      );
+      const json = await res.json();
+      expect(res.status).toBe(200);
+      expect(json.content).toBe('updated');
+    });
+
+    it('updates summary', async () => {
+      const res = await fetch(
+        `http://localhost:${port}/api/summary/${date}`,
+        {
+          method: 'PUT',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({summary: 'great day'}),
+        },
+      );
+      const json = await res.json();
+      expect(res.status).toBe(200);
+      expect(json.summary).toBe('great day');
+    });
+
+    it('reflects updates when fetching day', async () => {
+      const res = await fetch(
+        `http://localhost:${port}/api/entries?date=${date}`,
+      );
+      const json = await res.json();
+      expect(json.summary).toBe('great day');
+      expect(json.entries[0].content).toBe('updated');
+    });
   });
 });
+


### PR DESCRIPTION
## Summary
- require clients to supply password in `x-password` header for entry and summary APIs
- serialize journal writes to avoid concurrent data loss and drop server-level password cache
- document password header requirement and update tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b498f0d2c0832b9fcd8dcb36752fe6