### PR TITLE
fix: reset write lock after failed journal update

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -33,7 +33,7 @@ const updateJournal = async <T>(
   fn: (journal: Journal) => T | Promise<T>,
 ): Promise<T> => {
   let result: T;
-  writeLock = writeLock.then(async () => {
+  const current = writeLock.then(async () => {
     const {payload} = (await loadEncrypted(
       password,
       dataPath,
@@ -43,7 +43,10 @@ const updateJournal = async <T>(
     result = await fn(journal);
     await saveEncrypted(password, journal, dataPath, pubKeyPath);
   });
-  await writeLock;
+  writeLock = current.catch((err) => {
+    logger.error(`Journal update failed: ${(err as Error).message}`);
+  });
+  await current;
   return result!;
 };
 

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -141,6 +141,32 @@ describe('server APIs', () => {
       expect(json.summary).toBe('great day');
       expect(json.entries[0].content).toBe('updated');
     });
+
+    it('resets write lock after failed update', async () => {
+      const bad = await fetch(
+        `http://localhost:${port}/api/entries/nonexistent`,
+        {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-password': 'secret',
+          },
+          body: JSON.stringify({content: 'bogus'}),
+        },
+      );
+      expect(bad.status).toBe(404);
+      const res = await fetch(`http://localhost:${port}/api/entries`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-password': 'secret',
+        },
+        body: JSON.stringify({date, content: 'after fail'}),
+      });
+      const json = await res.json();
+      expect(res.status).toBe(201);
+      expect(json.content).toBe('after fail');
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- ensure journal write lock resolves even if a write fails
- add regression test confirming subsequent writes succeed after a failed update

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b49b45c824832ba8e3aeb56b27c527