### PR TITLE
fix: require per-request password and serialize journal writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This project targets the latest Node.js LTS release. Ensure your environment use
 The server exposes a small JSON API:
 
 - `POST /api/unlock` – supply `{password}` to decrypt the journal.
+- All other endpoints require the password in an `x-password` header.
 - `GET /api/entries?date=YYYY-MM-DD` – retrieve `{summary, entries}` for a day.
 - `POST /api/entries` – send `{date, content}` to append a new entry.
 - `PUT /api/entries/:id` – update an entry's `{content}` and optional `timestamp`.

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -71,7 +71,10 @@ describe('server APIs', () => {
     it('appends an entry', async () => {
       const res = await fetch(`http://localhost:${port}/api/entries`, {
         method: 'POST',
-        headers: {'Content-Type': 'application/json'},
+        headers: {
+          'Content-Type': 'application/json',
+          'x-password': 'secret',
+        },
         body: JSON.stringify({date, content: 'hello'}),
       });
       const json = (await res.json()) as {id: string; content: string};
@@ -83,6 +86,9 @@ describe('server APIs', () => {
     it('retrieves entries for the day', async () => {
       const res = await fetch(
         `http://localhost:${port}/api/entries?date=${date}`,
+        {
+          headers: {'x-password': 'secret'},
+        },
       );
       const json = await res.json();
       expect(res.status).toBe(200);
@@ -95,7 +101,10 @@ describe('server APIs', () => {
         `http://localhost:${port}/api/entries/${entryId}`,
         {
           method: 'PUT',
-          headers: {'Content-Type': 'application/json'},
+          headers: {
+            'Content-Type': 'application/json',
+            'x-password': 'secret',
+          },
           body: JSON.stringify({content: 'updated'}),
         },
       );
@@ -109,7 +118,10 @@ describe('server APIs', () => {
         `http://localhost:${port}/api/summary/${date}`,
         {
           method: 'PUT',
-          headers: {'Content-Type': 'application/json'},
+          headers: {
+            'Content-Type': 'application/json',
+            'x-password': 'secret',
+          },
           body: JSON.stringify({summary: 'great day'}),
         },
       );
@@ -121,6 +133,9 @@ describe('server APIs', () => {
     it('reflects updates when fetching day', async () => {
       const res = await fetch(
         `http://localhost:${port}/api/entries?date=${date}`,
+        {
+          headers: {'x-password': 'secret'},
+        },
       );
       const json = await res.json();
       expect(json.summary).toBe('great day');


### PR DESCRIPTION
## Summary
- require clients to supply password in `x-password` header for entry and summary APIs
- serialize journal writes to avoid concurrent data loss and drop server-level password cache
- document password header requirement and update tests
- use a `NotFoundError` to report missing entries and send JSON error bodies

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b498f0d2c0832b9fcd8dcb36752fe6