### PR TITLE
feat: add calendar-based entry management UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A minimal TypeScript project for a browser-based journal client. The HTML
 interface uses vanilla JavaScript and [w3.css](https://www.w3schools.com/w3css/).
+After unlocking, select a date to browse entries, add new notes, edit existing
+ones, and update a daily summary.
 Journal entries are encrypted locally using a symmetric key derived from a
 user-provided password. The key is never stored and session data is not
 persisted. Each save produces a new signing key pair: the public key is written

--- a/public/index.html
+++ b/public/index.html
@@ -16,8 +16,24 @@
         <p id="error" class="w3-text-red"></p>
       </form>
     </div>
-    <div id="content-view" class="w3-card w3-padding w3-margin-top w3-center" style="display:none">
-      <h1 id="title"></h1>
+    <div id="content-view" class="w3-card w3-padding w3-margin-top" style="display:none">
+      <h1 id="title" class="w3-center"></h1>
+      <input id="date-picker" class="w3-input w3-margin-top" type="date" />
+      <div class="w3-margin-top">
+        <label for="summary">Summary</label>
+        <textarea id="summary" class="w3-input"></textarea>
+        <button id="save-summary" class="w3-button w3-blue w3-margin-top">
+          Save Summary
+        </button>
+      </div>
+      <div class="w3-margin-top">
+        <label for="new-entry">New Entry</label>
+        <textarea id="new-entry" class="w3-input"></textarea>
+        <button id="add-entry" class="w3-button w3-green w3-margin-top">
+          Add Entry
+        </button>
+      </div>
+      <ul id="entries" class="w3-ul w3-margin-top"></ul>
     </div>
   </div>
   <script src="script.js"></script>

--- a/public/script.js
+++ b/public/script.js
@@ -4,22 +4,114 @@ const error = document.getElementById('error');
 const unlockView = document.getElementById('unlock-view');
 const contentView = document.getElementById('content-view');
 const title = document.getElementById('title');
+const datePicker = document.getElementById('date-picker');
+const entriesList = document.getElementById('entries');
+const newEntry = document.getElementById('new-entry');
+const addEntry = document.getElementById('add-entry');
+const summary = document.getElementById('summary');
+const saveSummary = document.getElementById('save-summary');
+
+let password = '';
+
+const renderEntries = (entries) => {
+  entriesList.innerHTML = '';
+  entries.forEach((entry) => {
+    const li = document.createElement('li');
+    li.className = 'w3-bar';
+    const span = document.createElement('span');
+    span.className = 'w3-bar-item';
+    span.textContent = entry.content;
+    const btn = document.createElement('button');
+    btn.className = 'w3-bar-item w3-button w3-small w3-right';
+    btn.textContent = 'Edit';
+    btn.addEventListener('click', async () => {
+      const updated = prompt('Edit entry', entry.content);
+      if (updated && updated !== entry.content) {
+        await fetch(`/api/entries/${entry.id}`, {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Password': password,
+          },
+          body: JSON.stringify({content: updated}),
+        });
+        loadDay(datePicker.value);
+      }
+    });
+    li.appendChild(span);
+    li.appendChild(btn);
+    entriesList.appendChild(li);
+  });
+};
+
+const loadDay = async (date) => {
+  try {
+    const res = await fetch(`/api/entries?date=${date}`, {
+      headers: {'X-Password': password},
+    });
+    if (res.ok) {
+      const day = await res.json();
+      summary.value = day.summary || '';
+      renderEntries(day.entries || []);
+    } else {
+      summary.value = '';
+      entriesList.innerHTML = '';
+    }
+  } catch {
+    summary.value = '';
+    entriesList.innerHTML = '';
+  }
+};
+
+datePicker.addEventListener('change', () => {
+  loadDay(datePicker.value);
+});
+
+addEntry.addEventListener('click', async () => {
+  const content = newEntry.value.trim();
+  if (!content) return;
+  await fetch('/api/entries', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Password': password,
+    },
+    body: JSON.stringify({date: datePicker.value, content}),
+  });
+  newEntry.value = '';
+  loadDay(datePicker.value);
+});
+
+saveSummary.addEventListener('click', async () => {
+  await fetch(`/api/summary/${datePicker.value}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Password': password,
+    },
+    body: JSON.stringify({summary: summary.value}),
+  });
+  loadDay(datePicker.value);
+});
 
 form.addEventListener('submit', async (e) => {
   e.preventDefault();
   error.textContent = '';
-  const password = passwordInput.value;
+  const pwd = passwordInput.value;
   try {
     const res = await fetch('/api/unlock', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ password }),
+      body: JSON.stringify({ password: pwd }),
     });
     if (res.ok) {
       const data = await res.json();
       title.textContent = data.payload.title;
       unlockView.style.display = 'none';
       contentView.style.display = 'block';
+      password = pwd;
+      datePicker.value = new Date().toISOString().split('T')[0];
+      loadDay(datePicker.value);
     } else if (res.status === 400) {
       const data = await res.json().catch(() => ({}));
       error.textContent = data.error || 'Password required';


### PR DESCRIPTION
## Summary
- add date picker, summary field, and entry list with edit buttons
- load and manage entries for selected date after unlock
- document date-based entry navigation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b49d09cdd4832b8acd0b5d9fac5c99