### PR TITLE
fix: prefill date picker using local time

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -110,7 +110,8 @@ form.addEventListener('submit', async (e) => {
       unlockView.style.display = 'none';
       contentView.style.display = 'block';
       password = pwd;
-      datePicker.value = new Date().toISOString().split('T')[0];
+      // prefill with the user's local date in YYYY-MM-DD format
+      datePicker.value = new Date().toLocaleDateString('en-CA');
       loadDay(datePicker.value);
     } else if (res.status === 400) {
       const data = await res.json().catch(() => ({}));


### PR DESCRIPTION
## Summary
- default the calendar picker to the user's local date

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b49eddd464832b8aee6bace1e3d4d5